### PR TITLE
Bad cookies

### DIFF
--- a/Show_Rottentomatoes_meter.user.js
+++ b/Show_Rottentomatoes_meter.user.js
@@ -36,6 +36,7 @@
 // @match       https://www.amazon.in/*
 // @match       https://www.amazon.it/*
 // @match       https://www.imdb.com/title/*
+// @match       https://www.imdb.com/*/title/*
 // @match       https://www.serienjunkies.de/*
 // @match       http://www.serienjunkies.de/*
 // @match       https://www.boxofficemojo.com/movies/*
@@ -732,9 +733,8 @@ const sites = {
             // Set language cookie to English, request current page in English, then restore language cookie or expire it if it didn't exist before
             const imdbID = document.location.pathname.match(/\/title\/(\w+)/)[1]
             const homePageUrl = 'https://www.imdb.com/title/' + imdbID + '/?ref_=nv_sr_1'
-            const langM = document.cookie.match(/lc-main=([^;]+)/)
-            const langBefore = langM ? langM[1] : ';expires=Thu, 01 Jan 1970 00:00:01 GMT'
-            document.cookie = 'lc-main=en-US'
+            document.cookie = 'international-seo=; domain=.imdb.com; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT'
+            document.cookie = 'lc-main=en-US; path=/title/' + imdbID + '; max-age=1'
             const response = await asyncRequest({
               url: homePageUrl,
               headers: {
@@ -743,7 +743,7 @@ const sites = {
             }).catch(function (response) {
               console.warn('ShowRottentomatoes: Error imdb02\nurl=' + homePageUrl + '\nstatus=' + response.status)
             })
-            document.cookie = 'lc-main=' + langBefore
+            if (!response.responseText) { throw `${scriptName}: Too many requests. AWS challenge protection kicked in` }
             // Extract <h1> title
             const parts = response.responseText.split('</span></h1>')[0].split('>')
             const title = parts[parts.length - 1]
@@ -800,9 +800,8 @@ const sites = {
             const imdbID = document.location.pathname.match(/\/title\/(\w+)/)[1]
             const homePageUrl = 'https://www.imdb.com/title/' + imdbID + '/?ref_=nv_sr_1'
             // Set language cookie to English, request current page in English, then restore language cookie or expire it if it didn't exist before
-            const langM = document.cookie.match(/lc-main=([^;]+)/)
-            const langBefore = langM ? langM[1] : ';expires=Thu, 01 Jan 1970 00:00:01 GMT'
-            document.cookie = 'lc-main=en-US'
+            document.cookie = 'international-seo=; domain=.imdb.com; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT'
+            document.cookie = 'lc-main=en-US; path=/title/' + imdbID + '; max-age=1'
             const response = await asyncRequest({
               url: homePageUrl,
               headers: {
@@ -811,7 +810,7 @@ const sites = {
             }).catch(function (response) {
               console.warn('ShowRottentomatoes: Error imdb03\nurl=' + homePageUrl + '\nstatus=' + response.status)
             })
-            document.cookie = 'lc-main=' + langBefore
+            if (!response.responseText) { throw `${scriptName}: Too many requests. AWS challenge protection kicked in` }
             // Extract <h1> title
             const parts = response.responseText.split('</span></h1>')[0].split('>')
             const title = parts[parts.length - 1]

--- a/Show_Rottentomatoes_meter.user.js
+++ b/Show_Rottentomatoes_meter.user.js
@@ -733,7 +733,7 @@ const sites = {
             const imdbID = document.location.pathname.match(/\/title\/(\w+)/)[1]
             const homePageUrl = 'https://www.imdb.com/title/' + imdbID + '/?ref_=nv_sr_1'
             const langM = document.cookie.match(/lc-main=([^;]+)/)
-            const langBefore = langM ? langM[0] : ';expires=Thu, 01 Jan 1970 00:00:01 GMT'
+            const langBefore = langM ? langM[1] : ';expires=Thu, 01 Jan 1970 00:00:01 GMT'
             document.cookie = 'lc-main=en-US'
             const response = await asyncRequest({
               url: homePageUrl,
@@ -801,7 +801,7 @@ const sites = {
             const homePageUrl = 'https://www.imdb.com/title/' + imdbID + '/?ref_=nv_sr_1'
             // Set language cookie to English, request current page in English, then restore language cookie or expire it if it didn't exist before
             const langM = document.cookie.match(/lc-main=([^;]+)/)
-            const langBefore = langM ? langM[0] : ';expires=Thu, 01 Jan 1970 00:00:01 GMT'
+            const langBefore = langM ? langM[1] : ';expires=Thu, 01 Jan 1970 00:00:01 GMT'
             document.cookie = 'lc-main=en-US'
             const response = await asyncRequest({
               url: homePageUrl,


### PR DESCRIPTION
Fixed a bug:
- const langBefore = langM ? langM[0] : ';expires=Thu, 01 Jan 1970 00:00:01 GMT'
+ const langBefore = langM ? langM[1] : ';expires=Thu, 01 Jan 1970 00:00:01 GMT'

and removed the line in following commit.

Setting a cookie on a path overrules and keeps the original cookie on root '/'.  
The cookie must be set on EN version, or rather the one that is going to be XHR, so that the page will not be redirected to e.g. https://www.imdb.com/fr/title/tt0093409/ (with "/fr/"). One second lifetime of the cookie, it will clear itself, restoring underlying original cookie on '/'.
Also international-seo must be removed. It does not need to be restored. Redirection in browser, where desired, still works without it.

It works as expected. But it's not exactly correct for non English movies. A French movie could have EN translated title.
I recommend XHR document and grab the LD. *name* is always original name. (check my script)


`// @match       https://www.imdb.com/*/title/*`  
This works for localized versions too.  


AWS challenge protection sometimes kicks in. Threshold is pretty low for some countries.  
Fetch/XHR of main title page will respond with 202 and an empty body.
throw. There is nothing else to do.
